### PR TITLE
Change the branch to be main instead of master.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Publish a release
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - '*'
 


### PR DESCRIPTION
We are not planning on using the word master to describe the primary branch for our respository, instead we will be using main.